### PR TITLE
チャット履歴をローカル保存＆表示

### DIFF
--- a/app/[docs_id]/chatForm.tsx
+++ b/app/[docs_id]/chatForm.tsx
@@ -27,9 +27,12 @@ export function ChatForm({ documentContent, sectionId }: ChatFormProps) {
       const savedHistory = localStorage.getItem(CHAT_HISTORY_KEY);
       if (savedHistory) {
         setMessages(JSON.parse(savedHistory));
+      } else {
+        setMessages([]);
       }
     } catch (error) {
       console.error("Failed to load chat history from localStorage", error);
+      setMessages([]);
     }
   }, [CHAT_HISTORY_KEY]);
 

--- a/app/[docs_id]/page.tsx
+++ b/app/[docs_id]/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({
   return (
     <div className="p-4">
       {splitMdContent.map((section, index) => (
-        <Section key={index} section={section} docs_id={docs_id} sectionIndex={index} />
+        <Section key={`${docs_id}-${index}`} section={section} docs_id={docs_id} sectionIndex={index} />
       ))}
     </div>
   );

--- a/app/[docs_id]/page.tsx
+++ b/app/[docs_id]/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({
   return (
     <div className="p-4">
       {splitMdContent.map((section, index) => (
-        <Section key={index} section={section} />
+        <Section key={index} section={section} docs_id={docs_id} sectionIndex={index} />
       ))}
     </div>
   );

--- a/app/[docs_id]/section.tsx
+++ b/app/[docs_id]/section.tsx
@@ -22,9 +22,14 @@ interface ISectionCodeContext {
 }
 const SectionCodeContext = createContext<ISectionCodeContext | null>(null);
 export const useSectionCode = () => useContext(SectionCodeContext);
+interface SectionProps {
+  section: MarkdownSection;
+  docs_id: string;
+  sectionIndex: number;
+}
 
 // 1つのセクションのタイトルと内容を表示する。内容はMarkdownとしてレンダリングする
-export function Section({ section }: { section: MarkdownSection }) {
+export function Section({ section, docs_id, sectionIndex }: SectionProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [replOutputs, setReplOutputs] = useState<ReplCommand[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -62,6 +67,7 @@ export function Section({ section }: { section: MarkdownSection }) {
   // fileContents: section内にあるファイルエディターの内容
   // execResults: section内にあるファイルの実行結果
   // console.log(section.title, replOutputs, fileContents, execResults);
+  const sectionId = `${docs_id}-${sectionIndex}`;
 
   return (
     <SectionCodeContext.Provider

--- a/app/[docs_id]/section.tsx
+++ b/app/[docs_id]/section.tsx
@@ -76,7 +76,7 @@ export function Section({ section, docs_id, sectionIndex }: SectionProps) {
       <div>
         <Heading level={section.level}>{section.title}</Heading>
         <StyledMarkdown content={section.content} />
-        <ChatForm documentContent={section.content} />
+        <ChatForm key={sectionId} documentContent={section.content} sectionId={sectionId} />
       </div>
     </SectionCodeContext.Provider>
   );

--- a/app/context/ChatHistoryContext.tsx
+++ b/app/context/ChatHistoryContext.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { createContext, ReactNode, useCallback, useContext, useState, useEffect } from "react";
+
+interface Message {
+  sender: "user" | "ai";
+  text: string;
+}
+
+interface IChatHistoryContext {
+  chatHistories: Record<string, Message[]>;
+  setChatHistory: (sectionId: string, messages: Message[]) => void;
+}
+
+const ChatHistoryContext = createContext<IChatHistoryContext | null>(null);
+
+export const useChatHistory = () => {
+  const context = useContext(ChatHistoryContext);
+  if (!context) {
+    throw new Error("useChatHistory must be used within a ChatHistoryProvider");
+  }
+  return context;
+};
+
+const CHAT_HISTORY_STORAGE_KEY = "my-code-all-chat-histories";
+
+export function ChatHistoryProvider({ children }: { children: ReactNode }) {
+  const [chatHistories, setChatHistories] = useState<Record<string, Message[]>>({});
+
+  useEffect(() => {
+    try {
+      const savedHistories = localStorage.getItem(CHAT_HISTORY_STORAGE_KEY);
+      if (savedHistories) {
+        setChatHistories(JSON.parse(savedHistories));
+      }
+    } catch (error) {
+      console.error("Failed to load chat histories from localStorage", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (Object.keys(chatHistories).length > 0) {
+      localStorage.setItem(CHAT_HISTORY_STORAGE_KEY, JSON.stringify(chatHistories));
+    } else {
+      const saved = localStorage.getItem(CHAT_HISTORY_STORAGE_KEY);
+      if(saved) localStorage.removeItem(CHAT_HISTORY_STORAGE_KEY);
+    }
+  }, [chatHistories]);
+
+  const setChatHistory = useCallback((sectionId: string, messages: Message[]) => {
+    setChatHistories((prevHistories) => {
+      const newHistories = { ...prevHistories };
+      if (messages.length === 0) {
+        delete newHistories[sectionId];
+      } else {
+        newHistories[sectionId] = messages;
+      }
+      return newHistories;
+    });
+  }, []);
+
+  return (
+    <ChatHistoryContext.Provider value={{ chatHistories, setChatHistory }}>
+      {children}
+    </ChatHistoryContext.Provider>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "./sidebar";
 import { ReactNode } from "react";
 import { PyodideProvider } from "./terminal/python/pyodide";
 import { FileProvider } from "./terminal/file";
+import { ChatHistoryProvider } from "./context/ChatHistoryContext";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -21,9 +22,11 @@ export default function RootLayout({
           <input id="drawer-toggle" type="checkbox" className="drawer-toggle" />
           <div className="drawer-content flex flex-col">
             <Navbar />
-            <FileProvider>
-              <PyodideProvider>{children}</PyodideProvider>
-            </FileProvider>
+            <ChatHistoryProvider>
+              <FileProvider>
+                <PyodideProvider>{children}</PyodideProvider>
+              </FileProvider>
+            </ChatHistoryProvider>
           </div>
           <div className="drawer-side shadow-md">
             <label


### PR DESCRIPTION
チャット履歴をローカルに保存し、ユーザーがページを再読み込みしたり、別のページに移動して戻ってきたりしても会話が残るようにしました。
- 各ドキュメントの各セクションごとにチャットが用意されていますが、それらの履歴が混在せず、完全に独立して保存・表示されるように修正しました。
- 最新のチャット１件のみが表示されるようになっています。

備考
- チャットの履歴もAIに渡して会話ができるようにしたい
- 履歴削除機能があったほうがいい
