### PR TITLE
質問の例をAIに考えさせる

### DIFF
--- a/app/[docs_id]/chatForm.tsx
+++ b/app/[docs_id]/chatForm.tsx
@@ -5,6 +5,7 @@ import { askAI } from "@/app/actions/chatActions";
 import { StyledMarkdown } from "./markdown";
 import useSWR from "swr";
 import { getQuestionExample } from "../actions/questionExample";
+import { getLanguageName } from "../pagesList";
 
 export function ChatForm({
   docs_id,
@@ -18,7 +19,7 @@ export function ChatForm({
   const [isLoading, setIsLoading] = useState(false);
   const [isFormVisible, setIsFormVisible] = useState(false);
 
-  const lang = docs_id.split("-")[0];
+  const lang = getLanguageName(docs_id);
   const { data: exampleData, error: exampleError } = useSWR(
     // 質問フォームを開いたときだけで良い
     isFormVisible ? { lang, documentContent } : null,

--- a/app/[docs_id]/page.tsx
+++ b/app/[docs_id]/page.tsx
@@ -42,7 +42,7 @@ export default async function Page({
     <div className="p-4">
       {splitMdContent.map((section, index) => (
         <div key={index} id={`${index}`}>
-          <Section key={index} section={section} />
+          <Section key={index} docs_id={docs_id} section={section} />
         </div>
       ))}
     </div>

--- a/app/[docs_id]/section.tsx
+++ b/app/[docs_id]/section.tsx
@@ -25,7 +25,13 @@ const SectionCodeContext = createContext<ISectionCodeContext | null>(null);
 export const useSectionCode = () => useContext(SectionCodeContext);
 
 // 1つのセクションのタイトルと内容を表示する。内容はMarkdownとしてレンダリングする
-export function Section({ section }: { section: MarkdownSection }) {
+export function Section({
+  docs_id,
+  section,
+}: {
+  docs_id: string;
+  section: MarkdownSection;
+}) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [replOutputs, setReplOutputs] = useState<ReplCommand[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -71,7 +77,7 @@ export function Section({ section }: { section: MarkdownSection }) {
       <div>
         <Heading level={section.level}>{section.title}</Heading>
         <StyledMarkdown content={section.content} />
-        <ChatForm documentContent={section.content} />
+        <ChatForm docs_id={docs_id} documentContent={section.content} />
       </div>
     </SectionCodeContext.Provider>
   );

--- a/app/actions/questionExample.ts
+++ b/app/actions/questionExample.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { z } from "zod";
+
+const QuestionExampleSchema = z.object({
+  lang: z.string().min(1),
+  documentContent: z.string().min(1),
+});
+
+const genAI = new GoogleGenerativeAI(process.env.API_KEY!);
+
+type QuestionExampleParams = z.input<typeof QuestionExampleSchema>;
+
+export async function getQuestionExample(
+  params: QuestionExampleParams
+): Promise<string[]> {
+  // 質問の例を複数AIに考えさせる。
+  // stringで複数返して、ChatForm側でその中から1つランダムに選ぶ
+  // 呼び出し側がSWRで、エラー処理してくれるので、全部throwでいい
+  // TODO: 同じドキュメントに対して2回以上生成する意味がないので、キャッシュしたいですね
+
+  const parseResult = QuestionExampleSchema.safeParse(params);
+
+  if (!parseResult.success) {
+    throw new Error(parseResult.error.issues.map((e) => e.message).join(", "));
+  }
+
+  const { lang, documentContent } = parseResult.data;
+
+  const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+  const prompt = `
+以下の${lang}チュートリアルのドキュメントに対して、想定される初心者のユーザーからの質問の例を箇条書きで複数挙げてください。
+強調などはせずテキストだけで1行ごとに1つ出力してください。
+
+# ドキュメント
+${documentContent}
+`;
+  const result = await model.generateContent(prompt);
+  const response = result.response;
+  const text = response.text();
+  return text.trim().split("\n");
+}

--- a/app/pagesList.ts
+++ b/app/pagesList.ts
@@ -30,3 +30,13 @@ export const pagesList = [
     ],
   },
 ] as const;
+
+// ${lang_id}-${page_id} から言語名を取得
+export function getLanguageName(docs_id: string){
+  const lang_id = docs_id.split("-")[0];
+  const lang = pagesList.find((lang) => lang.id === lang_id)?.lang;
+  if(!lang){
+    throw new Error(`Unknown language id: ${lang_id}`);
+  }
+  return lang;
+}


### PR DESCRIPTION
* 質問フォームを開くと、AIが考えた質問例が表示される
* 空欄の状態で送信ボタンを押した場合、その質問例を使う
* Section, ChatFormにdocs_idパラメーターを追加しました
* 言語名を扱う `getLanguageName(docs_id)` 関数を作りました (`cpp-1` → `C++` など)