### PR TITLE
NotoSansJPをやめる

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -124,24 +124,19 @@ mycdark:
 /* CDNからダウンロードするURLを指定したらなんかエラー出るので、npmでインストールしてlayout.tsxでimportすることにした */
 @theme {
   /*
-  Variable がついているほうはlayout.tsxでインポートしているwebフォント、
-  それ以外はフォールバック (インストールされていればwebフォントをダウンロードする必要はないため)
+  Inconsolata Variable はlayout.tsxでインポートしているwebフォント
 
-  UbuntuでシステムにインストールされたInconsolataには、太字がなかったので、Inconsolataは除外
+  UbuntuでシステムにインストールされたInconsolataには、太字がなかったので、Inconsolata は使用しない
   それに加えて、 "Inconsolata", "Inconsolata Variable" という指定にしたとしても
   terminal.tsxで Inconsolata Variable をloadしているので意味ない...
 
-  NotoSansJPの指定は正直なくても良い気はするが、
+  日本語フォントは正直なんでもいいが、
   あまり変なフォントが選ばれるとxtermやaceエディターの表示が崩れる可能性があるので、
-  確実にフォントを統一するために適当に指定している
+  確実にフォントを統一するためにRoundedM+を指定することにした
+  以前NotoSansJPを指定していたが、xterm.jsで全角の（）の幅がバグった
   */
   --font-mono:
-    "Inconsolata Variable",
-    /* Inconsolataのfallbackとしての欧文フォント */ "Inconsolata",
-    "Noto Sans Mono", "Roboto Mono", "SFMono-Regular", "Menlo", "Monaco",
-    "Consolas", "Liberation Mono", "Courier New",
-    /* 日本語用にNotoSans */ "Noto Sans Mono CJK JP", "Noto Sans JP",
-    "Noto Sans CJK JP", "Source Han Sans JP", "Noto Sans JP Variable", monospace;
+    "Inconsolata Variable", "Rounded M+ 1c", "Rounded M+ 1p", "M PLUS Rounded 1c", monospace;
   /*
   本家のフォント名は Rounded M+ 1c 、または1pでもいいかも
   layout.tsxでインポートしているwebフォントが M PLUS Rounded 1c

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import "@fontsource-variable/noto-sans-jp";
 import "@fontsource-variable/inconsolata";
 import "@fontsource/m-plus-rounded-1c/400.css";
 import "@fontsource/m-plus-rounded-1c/700.css";

--- a/app/terminal/terminal.tsx
+++ b/app/terminal/terminal.tsx
@@ -133,7 +133,7 @@ export function useTerminal(props: TerminalProps) {
             lineHeight: 1.2,
             letterSpacing: 0,
             fontFamily:
-              "'Inconsolata Variable', 'Noto Sans JP', 'Noto Sans CJK JP', 'Source Han Sans JP', '源ノ角ゴシック', 'Noto Sans JP Variable', monospace",
+              "'Inconsolata Variable', 'Rounded M+ 1c', 'Rounded M+ 1p', 'M PLUS Rounded 1c', monospace",
             theme: computeTerminalTheme(),
           });
           terminalInstanceRef.current = term;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/inconsolata": "^5.2.7",
-        "@fontsource-variable/noto-sans-jp": "^5.2.6",
         "@fontsource/m-plus-rounded-1c": "^5.2.9",
         "@google/genai": "^1.21.0",
         "@opennextjs/cloudflare": "^1.7.1",
@@ -8910,15 +8909,6 @@
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.2.7.tgz",
       "integrity": "sha512-vRCuyz9l7oHeU77Ed0+slKKf0oIx2Tq8/VkyH48tkclO6AySMLFmRZznm9SUyx1QqlMsqCDMF2KK0ysY5vJvWg==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/noto-sans-jp": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-jp/-/noto-sans-jp-5.2.6.tgz",
-      "integrity": "sha512-YjN8UF1hX8ZFkYx95NMz8XeojsCIF5dGPu1htoWkbXyTZj3Z29cxDT8glaT/cOg1BstyOlmtvNC8crPF5Csj/w==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@fontsource-variable/inconsolata": "^5.2.7",
-    "@fontsource-variable/noto-sans-jp": "^5.2.6",
     "@fontsource/m-plus-rounded-1c": "^5.2.9",
     "@google/genai": "^1.21.0",
     "@opennextjs/cloudflare": "^1.7.1",


### PR DESCRIPTION
xterm.jsで全角括弧の幅がなぜか3文字分になるバグが発生し、RoundedM+に変えてみたら解決した
